### PR TITLE
chore(): bump security updates (Feb 2025)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
     <spotbugs-maven-plugin.version>4.8.6.4</spotbugs-maven-plugin.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <assertj-core.version>3.26.3</assertj-core.version>
-    <netty.version>4.1.114.Final</netty.version>
-    <logback.version>1.5.10</logback.version>
+    <netty.version>4.1.118.Final</netty.version>
+    <logback.version>1.5.13</logback.version>
     <projectreactor.version>2023.0.9</projectreactor.version>
     <org.mapstruct.version>1.6.2</org.mapstruct.version>
     <org.mapstruct.binding.version>0.2.0</org.mapstruct.binding.version>
     <oauth2-oidc-sdk.version>11.20.1</oauth2-oidc-sdk.version>
-    <json.smart.version>2.5.1</json.smart.version>
+    <json.smart.version>2.5.2</json.smart.version>
     <beust.version>1.82</beust.version>
     <snake.yaml.version>2.3</snake.yaml.version>
 


### PR DESCRIPTION
- Netty 4.1.114.Final → 4.1.118.Final
- Logback 1.5.10 → 1.5.13
- JSON Smart 2.5.1 → 2.5.2